### PR TITLE
Add staging deployment automation

### DIFF
--- a/.github/workflows/deploy-stagging.yml
+++ b/.github/workflows/deploy-stagging.yml
@@ -179,7 +179,7 @@ jobs:
           set -euo pipefail
           SERVICE="${{ steps.vars.outputs.SERVICE }}"
           echo "• Restart service: ${SERVICE}"
-          systemctl restart "${SERVICE}"
+          sudo systemctl restart "${SERVICE}"
           echo "• Service status (short):"
           systemctl --no-pager --lines=20 status "${SERVICE}" || true
 


### PR DESCRIPTION
## Summary
- add a staging deployment script for Linux servers that syncs the behavior, resource, and skin packs
- create a GitHub Actions workflow to run the staging deploy script after pull requests merge into main or via manual dispatch

## Testing
- not run (infrastructure automation only)


------
https://chatgpt.com/codex/tasks/task_e_690034703f84832b840f49f2077f26fb