### PR TITLE
Add filtering controls to block palette spawner

### DIFF
--- a/src/main/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.ts
+++ b/src/main/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.ts
@@ -50,6 +50,7 @@ export class BlockPaletteSpawner {
 
     private static filterBlockTypes(blockTypes: any[], options: SpawnOptions): any[] {
         const excludeIds = new Set(options.excludeIds ?? []);
+        const excludePatterns = options.excludePatterns ?? [];
         const predicate = options.filter;
 
         return blockTypes.filter((blockType) => {
@@ -59,11 +60,25 @@ export class BlockPaletteSpawner {
                 return false;
             }
 
+            if (excludePatterns.length > 0 && this.isExcludedByPattern(blockId, excludePatterns)) {
+                return false;
+            }
+
             if (predicate) {
                 return predicate(blockId);
             }
 
             return true;
+        });
+    }
+
+    private static isExcludedByPattern(blockId: string, patterns: Array<string | RegExp>): boolean {
+        return patterns.some((pattern) => {
+            if (pattern instanceof RegExp) {
+                return pattern.test(blockId);
+            }
+
+            return blockId.startsWith(pattern);
         });
     }
 

--- a/src/main/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.ts
+++ b/src/main/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.ts
@@ -2,6 +2,32 @@ import { BlockTypes, world } from "@minecraft/server";
 import { PaletteLayout } from "./PaletteLayout";
 import type { SpawnOptions, SpawnResult } from "./block_palette_spawner.types";
 
+/**
+ * Bộ sinh block palette dùng để đặt toàn bộ block có sẵn trong game theo lưới.
+ *
+ * Tham số SpawnOptions chính:
+ * - dimensionId (bắt buộc): dimension cần spawn (ví dụ: overworld, nether, the_end).
+ * - maxBlocks, spacing, gridWidth, layerHeight, origin: kiểm soát giới hạn, khoảng cách, kích thước lưới và tọa độ gốc.
+ * - Bộ lọc loại trừ: excludeIds (Set/mảng id cụ thể) → excludePatterns (prefix string hoặc RegExp) → filter (predicate cuối cùng).
+ *   Thứ tự áp dụng: excludeIds → excludePatterns → filter.
+ *
+ * Ví dụ command (creator:spawnblockpalette):
+ * - Loại trừ nhiều ID cụ thể (CSV): `/creator:spawnblockpalette overworld 500 2 20 3 ~~~ id1,id2,id3`
+ * - Truyền JSON cho danh sách excludeIds: `/creator:spawnblockpalette overworld 300 2 15 3 ~~~ ["dirt","stone"]`
+ * - Loại trừ theo prefix và regex cho excludePatterns: `/creator:spawnblockpalette overworld 500 2 20 3 ~~~ "" ["element","/candle/"]`
+ *   (regex phải viết dạng `/pattern/` khi nhập lệnh).
+ *
+ * Ví dụ gọi API trực tiếp:
+ * ```ts
+ * await BlockPaletteSpawner.spawn({
+ *     dimensionId: "overworld",
+ *     excludeIds: ["element_core"],
+ *     excludePatterns: ["element", /candle/],
+ * });
+ * ```
+ *
+ * Kết quả trả về (SpawnResult): placed, failed, attempted, filtered và bounds (giới hạn khu vực spawn).
+ */
 export class BlockPaletteSpawner {
     public static spawn(options: SpawnOptions): SpawnResult {
         const spacing = options.spacing ?? undefined;

--- a/src/main/BP/core/api_wrapper/minecraft/block_palette/PaletteLayout.ts
+++ b/src/main/BP/core/api_wrapper/minecraft/block_palette/PaletteLayout.ts
@@ -21,8 +21,11 @@ export class PaletteLayout {
         const spacing = options.spacing ?? this.DEFAULT_SPACING;
         const gridWidth = Math.max(1, Math.floor(options.gridWidth ?? this.DEFAULT_GRID_WIDTH));
         const layerHeight = Math.max(1, Math.floor(options.layerHeight ?? this.DEFAULT_LAYER_HEIGHT));
-        const requestedMax = options.maxBlocks && options.maxBlocks > 0 ? Math.floor(options.maxBlocks) : availableBlocks;
-        const maxBlocks = Math.min(Math.max(1, requestedMax), availableBlocks);
+        const availableCount = Math.max(0, Math.floor(availableBlocks));
+        const requestedMax =
+            options.maxBlocks && options.maxBlocks > 0 ? Math.floor(options.maxBlocks) : availableCount;
+        const cappedRequested = availableCount === 0 ? 0 : Math.max(1, requestedMax);
+        const maxBlocks = Math.min(cappedRequested, availableCount);
 
         return { spacing, gridWidth, layerHeight, maxBlocks };
     }

--- a/src/main/BP/core/api_wrapper/minecraft/block_palette/block_palette_spawner.types.ts
+++ b/src/main/BP/core/api_wrapper/minecraft/block_palette/block_palette_spawner.types.ts
@@ -7,6 +7,14 @@ export type SpawnOptions = {
     gridWidth?: number;
     layerHeight?: number;
     maxBlocks?: number;
+    filter?: (blockId: string) => boolean;
+    excludeIds?: string[];
 };
 
-export type SpawnResult = { placed: number; failed: number; attempted: number; bounds: BoundingBox };
+export type SpawnResult = {
+    placed: number;
+    failed: number;
+    attempted: number;
+    filtered: number;
+    bounds: BoundingBox;
+};

--- a/src/main/BP/core/api_wrapper/minecraft/block_palette/block_palette_spawner.types.ts
+++ b/src/main/BP/core/api_wrapper/minecraft/block_palette/block_palette_spawner.types.ts
@@ -9,6 +9,7 @@ export type SpawnOptions = {
     maxBlocks?: number;
     filter?: (blockId: string) => boolean;
     excludeIds?: string[];
+    excludePatterns?: (string | RegExp)[];
 };
 
 export type SpawnResult = {

--- a/src/main/BP/core/commands/SpawnBlockPaletteCommand.ts
+++ b/src/main/BP/core/commands/SpawnBlockPaletteCommand.ts
@@ -6,7 +6,8 @@ export class SpawnBlockPaletteCommand {
         CustomCommandAPI.registerCommand(
             {
                 name: "creator:spawnblockpalette",
-                description: "Spawn a palette of every block in a grid for quick browsing",
+                description:
+                    "Spawn a palette of every block in a grid for quick browsing. Supports excludeIds/excludePatterns filters.",
                 permission: CustomCommandAPI.getPermission("Admin"),
                 parameters: [
                     { name: "dimensionId", type: CustomCommandAPI.getParameterType("String") },
@@ -15,10 +16,21 @@ export class SpawnBlockPaletteCommand {
                     { name: "gridWidth", type: CustomCommandAPI.getParameterType("Integer") },
                     { name: "layerHeight", type: CustomCommandAPI.getParameterType("Integer") },
                     { name: "origin", type: CustomCommandAPI.getParameterType("Location") },
+                    { name: "excludeIds", type: CustomCommandAPI.getParameterType("String") },
+                    { name: "excludePatterns", type: CustomCommandAPI.getParameterType("String") },
                 ],
             },
             ({ sender, args }) => {
-                const [dimensionArg, maxBlocksArg, spacingArg, gridWidthArg, layerHeightArg, originArg] = args ?? [];
+                const [
+                    dimensionArg,
+                    maxBlocksArg,
+                    spacingArg,
+                    gridWidthArg,
+                    layerHeightArg,
+                    originArg,
+                    excludeIdsArg,
+                    excludePatternsArg,
+                ] = args ?? [];
 
                 const dimensionId = dimensionArg || (sender.type !== "unknown" ? (sender as any).dimensionId : undefined);
                 const origin = originArg || (sender.type !== "unknown" ? (sender as any).location : undefined);
@@ -28,6 +40,8 @@ export class SpawnBlockPaletteCommand {
                 }
 
                 const parsedMaxBlocks = typeof maxBlocksArg === "number" && maxBlocksArg > 0 ? Math.floor(maxBlocksArg) : undefined;
+                const parsedExcludeIds = SpawnBlockPaletteCommand.parseStringList(excludeIdsArg);
+                const parsedExcludePatterns = SpawnBlockPaletteCommand.parsePatternList(excludePatternsArg);
 
                 SystemUtils.nextTick().then(() => {
                     const result = BlockPaletteSpawner.spawn({
@@ -37,6 +51,8 @@ export class SpawnBlockPaletteCommand {
                         spacing: spacingArg,
                         gridWidth: gridWidthArg,
                         layerHeight: layerHeightArg,
+                        excludeIds: parsedExcludeIds,
+                        excludePatterns: parsedExcludePatterns,
                     });
 
                     console.warn(
@@ -51,5 +67,67 @@ export class SpawnBlockPaletteCommand {
                 };
             }
         );
+    }
+
+    private static parseStringList(value: unknown): string[] | undefined {
+        if (value === undefined || value === null) {
+            return undefined;
+        }
+
+        if (Array.isArray(value)) {
+            const normalized = value.map(entry => `${entry}`.trim()).filter(Boolean);
+            return normalized.length > 0 ? normalized : undefined;
+        }
+
+        if (typeof value !== "string") {
+            return undefined;
+        }
+
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return undefined;
+        }
+
+        const parsedJson = this.tryParseJsonArray(trimmed);
+        if (parsedJson) {
+            const normalized = parsedJson.map(entry => `${entry}`.trim()).filter(Boolean);
+            return normalized.length > 0 ? normalized : undefined;
+        }
+
+        const parts = trimmed.split(",").map(part => part.trim()).filter(Boolean);
+        return parts.length > 0 ? parts : undefined;
+    }
+
+    private static parsePatternList(value: unknown): Array<string | RegExp> | undefined {
+        const stringList = this.parseStringList(value);
+        if (!stringList || stringList.length === 0) {
+            return undefined;
+        }
+
+        const patterns = stringList
+            .map(entry => {
+                if (entry.startsWith("/") && entry.endsWith("/") && entry.length > 2) {
+                    const pattern = entry.slice(1, -1);
+                    return new RegExp(pattern);
+                }
+                return entry;
+            })
+            .filter(Boolean);
+
+        return patterns.length > 0 ? patterns : undefined;
+    }
+
+    private static tryParseJsonArray(raw: string): unknown[] | undefined {
+        if (!raw.startsWith("[") || !raw.endsWith("]")) {
+            return undefined;
+        }
+
+        try {
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : undefined;
+        } catch (error) {
+            console.warn("[SpawnBlockPalette] Failed to parse JSON array for exclude options", error);
+            return undefined;
+        }
     }
 }

--- a/src/main/BP/core/commands/SpawnBlockPaletteCommand.ts
+++ b/src/main/BP/core/commands/SpawnBlockPaletteCommand.ts
@@ -43,6 +43,10 @@ export class SpawnBlockPaletteCommand {
                 const parsedExcludeIds = SpawnBlockPaletteCommand.parseStringList(excludeIdsArg);
                 const parsedExcludePatterns = SpawnBlockPaletteCommand.parsePatternList(excludePatternsArg);
 
+                console.warn(
+                    `[SpawnBlockPalette] Command args => sender=${"name" in sender ? (sender as any).name ?? sender.type : sender.type}, dimension=${dimensionId}, origin=${JSON.stringify(origin)}, maxBlocks(raw/parsed)=${maxBlocksArg}/${parsedMaxBlocks}, spacing=${spacingArg}, gridWidth=${gridWidthArg}, layerHeight=${layerHeightArg}, excludeIds(raw/parsed)=${excludeIdsArg}/${JSON.stringify(parsedExcludeIds)}, excludePatterns(raw/parsed)=${excludePatternsArg}/${JSON.stringify(parsedExcludePatterns)}`
+                );
+
                 SystemUtils.nextTick().then(() => {
                     const result = BlockPaletteSpawner.spawn({
                         dimensionId,

--- a/src/test/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.spec.ts
+++ b/src/test/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.spec.ts
@@ -134,4 +134,37 @@ describe("BlockPaletteSpawner", () => {
         });
         expect(placedBlockIds).toEqual(["block-0", "block-2"]);
     });
+
+    it("excludes blocks by pattern prefix", () => {
+        const placedBlockIds: string[] = [];
+        const mockDimension = {
+            getBlock: jest.fn(() => ({
+                setType: jest.fn((block: any) => placedBlockIds.push(block.id)),
+            })),
+        };
+
+        const { getDimension, getAllBlocks } = (globalThis as any).__mcServer;
+        getDimension.mockReturnValue(mockDimension);
+        getAllBlocks.mockReturnValue([
+            { id: "element_1" },
+            { id: "element_2" },
+            { id: "elemental_block" },
+            { id: "stone" },
+            { id: "dirt" },
+        ]);
+
+        const result = BlockPaletteSpawner.spawn({
+            dimensionId: "overworld",
+            excludePatterns: ["element"],
+        });
+
+        expect(result).toEqual({
+            placed: 2,
+            failed: 0,
+            attempted: 2,
+            filtered: 3,
+            bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 3, y: 0, z: 0 } },
+        });
+        expect(placedBlockIds).toEqual(["stone", "dirt"]);
+    });
 });

--- a/src/test/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.spec.ts
+++ b/src/test/BP/core/api_wrapper/minecraft/block_palette/BlockPaletteSpawner.spec.ts
@@ -50,6 +50,7 @@ describe("BlockPaletteSpawner", () => {
             placed: 10,
             failed: 0,
             attempted: 10,
+            filtered: 0,
             bounds: { min: { x: 0, y: 10, z: 0 }, max: { x: 4, y: 15, z: 4 } },
         });
 
@@ -101,7 +102,36 @@ describe("BlockPaletteSpawner", () => {
             placed: 2,
             failed: 2,
             attempted: 4,
+            filtered: 0,
             bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 2, y: 0, z: 2 } },
         });
+    });
+
+    it("excludes blocks using filter options and reports statistics", () => {
+        const placedBlockIds: string[] = [];
+        const mockDimension = {
+            getBlock: jest.fn(() => ({
+                setType: jest.fn((block: any) => placedBlockIds.push(block.id)),
+            })),
+        };
+
+        const { getDimension, getAllBlocks } = (globalThis as any).__mcServer;
+        getDimension.mockReturnValue(mockDimension);
+        getAllBlocks.mockReturnValue(new Array(5).fill(null).map((_, i) => ({ id: `block-${i}` })));
+
+        const result = BlockPaletteSpawner.spawn({
+            dimensionId: "overworld",
+            excludeIds: ["block-1", "block-3"],
+            filter: (blockId) => !blockId.endsWith("4"),
+        });
+
+        expect(result).toEqual({
+            placed: 2,
+            failed: 0,
+            attempted: 2,
+            filtered: 3,
+            bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 3, y: 0, z: 0 } },
+        });
+        expect(placedBlockIds).toEqual(["block-0", "block-2"]);
     });
 });

--- a/src/test/BP/core/commands/SpawnBlockPaletteCommand.spec.ts
+++ b/src/test/BP/core/commands/SpawnBlockPaletteCommand.spec.ts
@@ -60,6 +60,8 @@ describe("SpawnBlockPaletteCommand", () => {
             spacing: undefined,
             gridWidth: undefined,
             layerHeight: undefined,
+            excludeIds: undefined,
+            excludePatterns: undefined,
         });
         expect(response).toEqual({ message: "Starting block palette generation...", status: 0 });
     });
@@ -81,6 +83,8 @@ describe("SpawnBlockPaletteCommand", () => {
             spacing: undefined,
             gridWidth: undefined,
             layerHeight: undefined,
+            excludeIds: undefined,
+            excludePatterns: undefined,
         });
 
         commandHandler?.(ctx, "overworld", 12);
@@ -92,6 +96,8 @@ describe("SpawnBlockPaletteCommand", () => {
             spacing: undefined,
             gridWidth: undefined,
             layerHeight: undefined,
+            excludeIds: undefined,
+            excludePatterns: undefined,
         });
     });
 
@@ -116,6 +122,35 @@ describe("SpawnBlockPaletteCommand", () => {
             spacing: 2,
             gridWidth: 2,
             layerHeight: 3,
+            excludeIds: undefined,
+            excludePatterns: undefined,
+        });
+    });
+
+    it("parses exclude ids and patterns from arguments", async () => {
+        const spawnSpy = jest.spyOn(BlockPaletteSpawner, "spawn").mockReturnValue({
+            placed: 4,
+            failed: 0,
+            attempted: 4,
+            bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+        });
+        SpawnBlockPaletteCommand.register();
+
+        const ctx = { sourceEntity: { location: { x: 2, y: 2, z: 2 }, dimension: { id: "overworld" } } };
+
+        commandHandler?.(ctx, "overworld", undefined, undefined, undefined, undefined, undefined, "stone, dirt ",
+            "element,/candle/");
+
+        await Promise.resolve();
+        expect(spawnSpy).toHaveBeenCalledWith({
+            dimensionId: "overworld",
+            origin: { x: 2, y: 2, z: 2 },
+            maxBlocks: undefined,
+            spacing: undefined,
+            gridWidth: undefined,
+            layerHeight: undefined,
+            excludeIds: ["stone", "dirt"],
+            excludePatterns: ["element", /candle/],
         });
     });
 });


### PR DESCRIPTION
## Summary
- add filter and exclude options to palette spawning and report filtered counts
- cap palette layout based on filtered block availability and track attempts precisely
- verify filtering behavior with new unit coverage for block palette spawner

## Testing
- npm run build
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c366a078832bafb95c8b1da449ad)